### PR TITLE
Remove installed kernel sources and install the right versions

### DIFF
--- a/boxes/Vagrantfile
+++ b/boxes/Vagrantfile
@@ -59,13 +59,22 @@ Vagrant.configure("2") do |config|
         libaio
     "
 
+  # Remove installed kernel-devel and kernel-headers to prevent version missmatches
+  config.vm.provision "shell",
+    name:   "Remove installed kernel-devel and kernel-headers to prevent version missmatches",
+    inline: "
+      /usr/bin/yum remove -y\
+        kernel-devel\
+        kernel-headers\
+    "
+
   # Install RPMs required by Spectrum Scale to build portability layer
   config.vm.provision "shell",
     name:   "Install RPMs required by Spectrum Scale to build portability layer",
     inline: "
       /usr/bin/yum install -y\
-        kernel-devel-3.10.0-957.1.3.el7\
-        kernel-headers-3.10.0-957.1.3.el7\
+        kernel-devel-$(uname -r)\
+        kernel-headers-$(uname -r)\
         cpp\
         gcc\
         gcc-c++


### PR DESCRIPTION
Tried to fixed the issue https://github.com/IBM/SpectrumScaleVagrant/issues/3

- Remove installed kernel-devel and kernel-headers 
- Install the right versions of kernel-devel and kernel-headers 

```bash
[vagrant@m1 ~]$ sudo yum list installed | grep kernel
kernel.x86_64                      3.10.0-957.1.3.el7        @koji-override-1
kernel-devel.x86_64                3.10.0-957.1.3.el7        @updates
kernel-headers.x86_64              3.10.0-957.1.3.el7        @updates
kernel-tools.x86_64                3.10.0-957.1.3.el7        @koji-override-1
kernel-tools-libs.x86_64           3.10.0-957.1.3.el7        @koji-override-1
[vagrant@m1 ~]$ sudo mmhealth node show

Node name:      m1.example.com
Node status:    TIPS
Status Change:  16 min. ago

Component      Status        Status Change     Reasons
----------------------------------------------------------------------------------------
GPFS           TIPS          16 min. ago       callhome_not_enabled, gpfs_pagepool_small
NETWORK        HEALTHY       17 min. ago       -
FILESYSTEM     HEALTHY       13 min. ago       -
DISK           HEALTHY       15 min. ago       -
PERFMON        HEALTHY       15 min. ago       -
THRESHOLD      HEALTHY       15 min. ago       -
```