### PR TITLE
Cleanup virtualbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
 # Spectrum Scale Vagrant
 Example scripts and configuration files to install and configure IBM Spectrum Scale in a Vagrant environment.
 
+
 ## Installation
 
-The scripts and configuration files provision a virtual Spectrum Scale cluster using Vagrant and VirtualBox.
+The scripts and configuration files provision a single node Spectrum Scale cluster using Vagrant.
 
-### Install Vagrant and VirtualBox
-
-Follow the [Vagrant Getting Started Guide](https://www.vagrantup.com/intro/getting-started/index.html) to install Vagrant and VirtualBox and to get familiar with Vagrant.
-
-### Get the scripts and configuration files
+### Get the scripts and configuration files from GitHub
 
 Open a Command Prompt and clone the GitHub repository:
 1. `git clone https://github.com/IBM/SpectrumScaleVagrant.git`
@@ -23,44 +20,37 @@ Download the `Spectrum_Scale_Data_Management-5.0.2.2-x86_64-Linux-install` packa
 
 Vagrant will copy this file during the provisioning from the `host` to directory `/software` on the management node `m1`.
 
-### SpectrumScale_base.box - A Vagrant box optimized for Spectrum Scale
+### Install Vagrant
 
-The virtual machines are based on the [official Vagrant CentOS/7 boxes](https://app.vagrantup.com/centos/boxes/7). Spectrum Scale requires a couple of additional RPMs. We create a custom Vagrant box to accelerate the provisioning of the virtual machines for the Spectrum Scale environment.
+Follow the [Vagrant Getting Started Guide](https://www.vagrantup.com/intro/getting-started/index.html) to install Vagrant to get familiar with Vagrant.
 
-To create the custom Vagrant box:
-1. `cd boxes`
-1. `vagrant up`
-1. `vagrant package SpectrumScale_base --output SpectrumScale_base.box`
-1. `vagrant destroy`
-1. `cd ..`
 
-## Environments
+## Provisioning
 
-This version of SpectrumScaleVagrant provides tooling to provision
-* a single node Spectrum Scale cluster comprising one node only
+Spectrum Scale Vagrant supports the creation of a single node Spectrum Scale cluster on VirtualBox and on AWS. There is a subdirectory for each supported provider. Follow the instructions in the subdirectory of your preferred provider to install and configure a virtual machine.
 
-It is planned to add configurations with multiple nodes later.
+| Directory                  | Provider            |
+|----------------------------|---------------------|
+| [aws](./aws)               | Amazon Web Services |
+| [virtualbox](./virtualbox) | VirtualBox          |
 
-### Security
 
-The environments are optimized to play with Spectrum Scale in a lab environment. To simplify access from the outside, all virtual nodes are configured with well known SSH keys. This is a security exposure for production environments.
+Once the virtual enivironment is provided, Spectrum Scale Vagrant uses the same scripts to install and configure Spectrum Scale. Spectrum Scale Vagrant executes those scripts automatically during the provisining process (`vagrant up`) for your preferred provider.
 
-### Single node cluster
+| Directory                        | Provider                                                            |
+|----------------------------------|---------------------------------------------------------------------|
+| [setup/install](./setup/install) | Perform all steps to provision a Spectrum Scale cluster             |
+| [setup/demo](./setup/demo)       | Perform all steps to configure the Spectrum Scale for demo purposes |
 
-The single node cluster is good enough for many lab exercises and for
-developing and testing most of the scripts of this project.
 
-The advantage of the single node cluster is that it is much faster provisioned
-than a multi node cluster.
+## Spectrum Scale Management Interfaces
 
-The scripts for the single node cluster are stored in `single`.
+Spectrum Scale Vagrant uses the Spectrum Scale CLI and the Spectrum Scale REST API to install and configure Spectrum Scale. In addition it configures the Spectrum Scale GUI to allow interested users to explore its capabilities.
 
-To create and logon on a single node cluster:
-1. `cd single`
-1. `vagrant up`
-1. `vagrant ssh`
+### Spectrum Scale CLI
 
-Configuration of Spectrum Scale Cluster:
+Spectrum Scale Vagrant configures the shell `$PATH` variable and the sudo `secure_path` to include the location of the Spectrum Scale executables.
+
 ```
 [vagrant@m1 ~]$ sudo mmlscluster
 
@@ -79,16 +69,6 @@ GPFS cluster information
 
 [vagrant@m1 ~]$
 ```
-
-### Spectrum Scale GUI
-
-To connect to the Spectrum Scale GUI, enter `https://localhost:8888` in a browser. The GUI is configured with a self-signed certificate. The login screen shows, after accepting the certificate. The user `admin` has the default password `admin001`.
-
-![](/doc/gui/gui_login.png)
-
-Cluster overview in Spectrum Scale GUI:
-
-![](/doc/gui/gui_home_overview.png)
 
 ### Spectrum Scale REST API
 
@@ -143,6 +123,17 @@ es'
 
 [vagrant@m1 ~]$
 ```
+
+### Spectrum Scale GUI
+
+To connect to the Spectrum Scale GUI, enter `https://localhost:8888` in a browser. The GUI is configured with a self-signed certificate. The login screen shows, after accepting the certificate. The user `admin` has the default password `admin001`.
+
+![](/doc/gui/gui_login.png)
+
+Cluster overview in Spectrum Scale GUI:
+
+![](/doc/gui/gui_home_overview.png)
+
 
 ## Spectrum Scale Filesystem
 

--- a/aws/README.md
+++ b/aws/README.md
@@ -1,6 +1,6 @@
 # SpectrumScaleVagrant for AWS
 
-The scripts and files in this directory includes the tooling to provision and
+The scripts and files in this directory include the tooling to provision and
 configure the example Spectrum Scale cluster on AWS.
 
 ## Install the Vagrant plugin for AWS (vagrant-aws)
@@ -23,8 +23,8 @@ vagrant plugin install vagrant-aws
 Vagrant requires each provider plug-in to provide its own box format. The
 vagrant-aws plugin provides a [dummy box](https://github.com/mitchellh/vagrant-aws#box-format)
 to get the plugin going. In contrast to other box formats this box format does
-not include images of virtual machines, but a reference to an Amazon AMI stored
-on AWS.
+not include images of virtual machines. Instead the `Vagrantfile` needs to specify
+the AMI ID of an available AWS AMI.
 
 To [add the vagrant-aws dummy box](https://github.com/mitchellh/vagrant-aws#quick-start)
 to your Vagrant installation:
@@ -56,7 +56,7 @@ and to subscribe it in order to accept the license agreement.
 ## Decide on how to integrate the Spectrum Scale self-extracting installation package
 
 Depending on your network connectivity, it takes some time to upload the Spectrum Scale self-extracting installation package into AWS. There are two approach options to optimize the creation of the AWS AMI image for Spectrum Scale:
-1. Save the self-extracting installation package to `SpectrumScaleVagrant\software` before you to boot the virtual machine from which you create the Spectrum Scale AWS AMI. Then Vagrant will automatically copy it from your host to the virtual machine in AWS.
+1. Save the self-extracting installation package to `SpectrumScaleVagrant\software` before you to boot the virtual machine from which you create the Spectrum Scale AWS AMI. Then Vagrant will automatically copy it during the provisioning process (`Vagrant up`) from your host to the virtual machine in AWS.
 1. Copy the self-extracting installation package to `/software` of your virtual machine, after you have booted it. This approach is faster, if you have a copy for instance in an S3 bucket.
 
 ## Spectrum Scale Base AMI - An AWS AMI optimized for Spectrum Scale
@@ -85,7 +85,7 @@ Connection to ec2-34-224-86-55.compute-1.amazonaws.com closed.
 SpectrumScaleVagrant\aws\prep-ami>
 ```
 
-By default the CentOS AMI leaves the orphaned root volume, after the owning virtual machine (instance) is terminated. Amazon charges for orphaned root volumes. They either need to be deleted manually, or the initial virtual machine needs to be modified, before the Spectrum Scale Base AMI is created. See the Amazon documentation ([Changing the Root Device Volume to Persist](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/RootDeviceStorage.html#Using_RootDeviceStorage)) for details. The procedure requires the [installation of the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html).
+By default the official CentOS AMI and derived AMIs leave the orphaned root volume, after the owning virtual machine (instance) is terminated. Amazon charges for orphaned root volumes. They either need to be deleted manually, or the initial virtual machine needs to be modified, before the Spectrum Scale Base AMI is created. See the Amazon documentation ([Changing the Root Device Volume to Persist](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/RootDeviceStorage.html#Using_RootDeviceStorage)) for details. The procedure requires the [installation of the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html). Follow the AWS documentation for the installation of the AWS CLI.
 
 First step is to query the `InstanceId` and the setting for `DeleteOnTermination` of the running virtual machine:
 

--- a/virtualbox/README.md
+++ b/virtualbox/README.md
@@ -30,3 +30,12 @@ The environment on VirtualBox is optimized to play with Spectrum Scale
 in a lab environment. To simplify access from the outside, all virtual
 nodes are configured with well known SSH keys. This is a security exposure
 for production environments.
+
+## Boot a virtual machine with a single node Spectrum Scale cluster
+
+Now we are ready to boot a virtual machine on VirtualBox and to configure it with a single node Spectrum Scale cluster:
+1. `cd SpectrumScaleVagrant\virtualbox`
+1. `vagrant up`
+1. `vagrant ssh`
+
+See the [README.md](../README.md) for details on the configured Spectrum Scale cluster.

--- a/virtualbox/README.md
+++ b/virtualbox/README.md
@@ -23,3 +23,10 @@ To create the custom Vagrant box:
 1. `vagrant up`
 1. `vagrant package SpectrumScale_base --output SpectrumScale_base.box`
 1. `vagrant destroy`
+
+## Security
+
+The environment on VirtualBox is optimized to play with Spectrum Scale
+in a lab environment. To simplify access from the outside, all virtual
+nodes are configured with well known SSH keys. This is a security exposure
+for production environments.

--- a/virtualbox/README.md
+++ b/virtualbox/README.md
@@ -1,35 +1,35 @@
 # SpectrumScaleVagrant for VirtualBox
 
-The scripts and files in this directory includes the tooling to provision and
+The scripts and files in this directory include the tooling to provision and
 configure the example Spectrum Scale cluster on VirtualBox.
 
 ## Install VirtualBox
 
-After installing [SpectrumScaleVagrant and Vagrant itself](../README.md) you
+In addition to [SpectrumScaleVagrant and Vagrant itself](../README.md) you
 need to install [VirtualBox](https://www.virtualbox.org/). The installation of
-VirtualBox is straight forward. Just fullow the documentation.
+VirtualBox is straight forward. Just fullow the VirtualBox documentation.
+
+## Security
+
+SpectrumScaleVagrant for VirtualBox is optimized to play with Spectrum Scale
+in a lab environment. To simplify access from the outside, all virtual
+nodes are configured with well known SSH keys. This is a security exposure
+for production environments.
 
 ## SpectrumScale_base.box - A Vagrant box optimized for Spectrum Scale
 
 The virtual machines are based on the [official Vagrant CentOS/7 boxes](https://app.vagrantup.com/centos/boxes/7).
 Spectrum Scale requires a couple of additional RPMs. We create a custom 
-Spectrum Scale Vagrant box to accelerate the provisioning of the virtual
-machines for the Spectrum Scale environment. The official CentOS box and the
-additional RPMs will be downloaded during the provisioning process
-(`vagrant up`).
+Vagrant Spectrum Scale box to accelerate the provisioning of the virtual
+machines for the Spectrum Scale environment. The official Vagrant CentOS box
+and the additional CentOS RPMs will be downloaded during the provisioning
+process (`vagrant up`).
 
-To create the custom Vagrant box:
+To create the custom Vagrant Spectrum Scale box:
 1. `cd SpectrumScaleVagrant\virtualbox\prep-box`
 1. `vagrant up`
 1. `vagrant package SpectrumScale_base --output SpectrumScale_base.box`
 1. `vagrant destroy`
-
-## Security
-
-The environment on VirtualBox is optimized to play with Spectrum Scale
-in a lab environment. To simplify access from the outside, all virtual
-nodes are configured with well known SSH keys. This is a security exposure
-for production environments.
 
 ## Boot a virtual machine with a single node Spectrum Scale cluster
 
@@ -38,4 +38,5 @@ Now we are ready to boot a virtual machine on VirtualBox and to configure it wit
 1. `vagrant up`
 1. `vagrant ssh`
 
-See the [README.md](../README.md) for details on the configured Spectrum Scale cluster.
+See the [README.md](../README.md) for details on the configured Spectrum Scale
+cluster.

--- a/virtualbox/README.md
+++ b/virtualbox/README.md
@@ -1,0 +1,10 @@
+# SpectrumScaleVagrant for VirtualBox
+
+The scripts and files in this directory includes the tooling to provision and
+configure the example Spectrum Scale cluster on VirtualBox.
+
+## Install VirtualBox
+
+After installing [SpectrumScaleVagrant and Vagrant itself](../README.md) you
+need to install [VirtualBox](https://www.virtualbox.org/). The installation of
+VirtualBox is straight forward. Just fullow the documentation.

--- a/virtualbox/README.md
+++ b/virtualbox/README.md
@@ -8,3 +8,18 @@ configure the example Spectrum Scale cluster on VirtualBox.
 After installing [SpectrumScaleVagrant and Vagrant itself](../README.md) you
 need to install [VirtualBox](https://www.virtualbox.org/). The installation of
 VirtualBox is straight forward. Just fullow the documentation.
+
+## SpectrumScale_base.box - A Vagrant box optimized for Spectrum Scale
+
+The virtual machines are based on the [official Vagrant CentOS/7 boxes](https://app.vagrantup.com/centos/boxes/7).
+Spectrum Scale requires a couple of additional RPMs. We create a custom 
+Spectrum Scale Vagrant box to accelerate the provisioning of the virtual
+machines for the Spectrum Scale environment. The official CentOS box and the
+additional RPMs will be downloaded during the provisioning process
+(`vagrant up`).
+
+To create the custom Vagrant box:
+1. `cd SpectrumScaleVagrant\virtualbox\prep-box`
+1. `vagrant up`
+1. `vagrant package SpectrumScale_base --output SpectrumScale_base.box`
+1. `vagrant destroy`

--- a/virtualbox/Vagrantfile
+++ b/virtualbox/Vagrantfile
@@ -35,7 +35,7 @@ Vagrant.configure("2") do |config|
 
   # Use the Vagrant box prepared for Spectrum Scale
   config.vm.box     = "SpectrumScale_base"
-  config.vm.box_url = "../boxes/SpectrumScale_base.box"
+  config.vm.box_url = "./prep-box/SpectrumScale_base.box"
 
   # Customize resources of virtual machines
   config.vm.provider "virtualbox" do |vbox|

--- a/virtualbox/prep-box/Vagrantfile
+++ b/virtualbox/prep-box/Vagrantfile
@@ -22,7 +22,7 @@ EOT
 
 
 # Load RPMs that need to be installed on top of the CentOS base image
-load File.expand_path('../../shared/Vagrantfile.rpms', __FILE__)
+load File.expand_path('../../../shared/Vagrantfile.rpms', __FILE__)
 
 
 Vagrant.configure("2") do |config|


### PR DESCRIPTION
Moved the Vagrantfiles for virtualbox to directory virtualbox to have the same directory layout for all providers. Updated the README to cover both provider, AWS and VirtualBox.