### PR TITLE
Fix AWS deployment issues, add Object support for AWS

### DIFF
--- a/aws/Vagrantfile
+++ b/aws/Vagrantfile
@@ -29,6 +29,17 @@ load File.expand_path('../Vagrantfile.aws-ami', __FILE__)
 # Load common settings
 load File.expand_path('../../shared/Vagrantfile.common', __FILE__)
 
+# Workaround for vagrant-aws issue https://github.com/mitchellh/vagrant-aws/issues/566
+class Hash
+  def slice(*keep_keys)
+    h = {}
+    keep_keys.each { |key| h[key] = fetch(key) if has_key?(key) }
+    h
+  end unless Hash.method_defined?(:slice)
+  def except(*less_keys)
+    slice(*keys - less_keys)
+  end unless Hash.method_defined?(:except)
+end
 
 # Customize configuration specific settings
 Vagrant.configure("2") do |config|
@@ -52,10 +63,14 @@ Vagrant.configure("2") do |config|
     override.ssh.private_key_path = $my_aws_private_key_path
 
     # Pin the AWS region
+    # aws.region = "eu-central-1"
     aws.region = "us-east-1"
 
     # Pin the SpectrumScale_base AMI
     aws.ami = $my_aws_SpectrumScale_base_AMI_ID
+
+    # Set instance type - default is m3.medium - we need more RAM for CES
+    aws.instance_type = "m3.large"
 
     # Set user name for CentOS images
     override.ssh.username = "centos"
@@ -66,13 +81,13 @@ Vagrant.configure("2") do |config|
 
     # Add disks for SpectrumScale NSDs
     aws.block_device_mapping = [
-      { 'DeviceName' => '/dev/xvdb', 'Ebs.VolumeSize' =>  2 },
-      { 'DeviceName' => '/dev/xvdc', 'Ebs.VolumeSize' =>  2 },
-      { 'DeviceName' => '/dev/xvdd', 'Ebs.VolumeSize' =>  2 },
-      { 'DeviceName' => '/dev/xvde', 'Ebs.VolumeSize' =>  2 },
-      { 'DeviceName' => '/dev/xvdf', 'Ebs.VolumeSize' =>  2 },
-      { 'DeviceName' => '/dev/xvdg', 'Ebs.VolumeSize' => 10 },
-      { 'DeviceName' => '/dev/xvdh', 'Ebs.VolumeSize' => 10 },      
+      { 'DeviceName' => '/dev/xvdb', 'Ebs.VolumeSize' =>  3 },
+      { 'DeviceName' => '/dev/xvdc', 'Ebs.VolumeSize' =>  3 },
+      { 'DeviceName' => '/dev/xvdd', 'Ebs.VolumeSize' =>  3 },
+      { 'DeviceName' => '/dev/xvde', 'Ebs.VolumeSize' =>  3 },
+      { 'DeviceName' => '/dev/xvdf', 'Ebs.VolumeSize' =>  3 },
+      { 'DeviceName' => '/dev/xvdg', 'Ebs.VolumeSize' => 5 },
+      { 'DeviceName' => '/dev/xvdh', 'Ebs.VolumeSize' => 5 },
     ]
 
 

--- a/aws/prep-ami/Vagrantfile
+++ b/aws/prep-ami/Vagrantfile
@@ -14,7 +14,19 @@ EOT
 load File.expand_path('../../Vagrantfile.aws-credentials', __FILE__)
 
 # Load RPMs that need to be installed on top of the CentOS base image
-load File.expand_path('../../../shared/Vagrantfile.rpms', __FILE__)
+load File.expand_path('../../../shared/Vagrantfile8.rpms', __FILE__)
+
+# Workaround for vagrant-aws issue https://github.com/mitchellh/vagrant-aws/issues/566
+class Hash
+  def slice(*keep_keys)
+    h = {}
+    keep_keys.each { |key| h[key] = fetch(key) if has_key?(key) }
+    h
+  end unless Hash.method_defined?(:slice)
+  def except(*less_keys)
+    slice(*keys - less_keys)
+  end unless Hash.method_defined?(:except)
+end
 
 
 # Customize configuration specific settings
@@ -37,10 +49,14 @@ Vagrant.configure("2") do |config|
     override.ssh.private_key_path = $my_aws_private_key_path
 
     # Pin the AWS region
+    # aws.region = "eu-central-1"
     aws.region = "us-east-1"
 
-    # Pin the CentOS 7 AMI
-    aws.ami = "ami-02eac2c0129f6376b"
+    # Pin the CentOS 8 AMI
+    # CentOS 8 AMI for eu-central-1
+    # aws.ami = "ami-04c21037b3f953d37"
+    # CentOS 8 AMI for us-east-1
+    aws.ami = "ami-0d6e9a57f6259ba3a"
 
     # Set user name for CentOS images
     override.ssh.username = "centos"

--- a/setup/demo/script.sh
+++ b/setup/demo/script.sh
@@ -47,10 +47,7 @@ esac
 /vagrant/demo/script-05.sh
 /vagrant/demo/script-06.sh
 #/vagrant/demo/script-07.sh
-if [ "$PROVIDER" = "VirtualBox" -o "$PROVIDER" = "libvirt" ]
-then
-    /vagrant/demo/script-08.sh
-fi
+/vagrant/demo/script-08.sh $PROVIDER
 
 # Tweak the configuration to show more management capabilities
 /vagrant/demo/script-80.sh

--- a/setup/install/script-04.sh
+++ b/setup/install/script-04.sh
@@ -63,7 +63,8 @@ sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale node list
 # ... for AWS
 if [ "$PROVIDER" = "AWS" ]
 then
-  sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale nsd add -p m1.example.com -fs fs1 /dev/xvdb /dev/xvdc /dev/xvdd /dev/xvde /dev/xvdf
+  sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale nsd add -p m1.example.com -fs fs1 /dev/xvdb /dev/xvdc /dev/xvdd
+  sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale nsd add -p m1.example.com -fs cesShared /dev/xvde /dev/xvdf
   sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale nsd add -p m1.example.com /dev/xvdg /dev/xvdh
 fi
 # ... for VirtualBox

--- a/setup/install/script-08.sh
+++ b/setup/install/script-08.sh
@@ -8,9 +8,6 @@ usage(){
   echo "  libvirt"
 }
 
-# Exit on error
-set -e
-
 # Improve readability of output
 echo "========================================================================================="
 echo "===>"
@@ -49,7 +46,8 @@ sudo dnf -y upgrade
 
 echo "===> configuring Object"
 sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale node add m1.example.com -p
-sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale config protocols -e 192.168.56.101
+CESVIP=$(grep "cesip" /etc/hosts | awk {'print $1'})
+sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale config protocols -e $CESVIP
 sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale config protocols -f cesShared -m /ibm/cesShared
 sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale enable object
 sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale config object -f fs1 -m /ibm/fs1 -e cesip.example.com -au admin -dp passw0rd -sp passw0rd -ap passw0rd

--- a/setup/install/script.sh
+++ b/setup/install/script.sh
@@ -51,11 +51,7 @@ esac
 /vagrant/install/script-05.sh $PROVIDER
 /vagrant/install/script-06.sh $PROVIDER
 /vagrant/install/script-07.sh $PROVIDER
-# Do not install Object on AWS (yet)
-if [ "$PROVIDER" = "VirtualBox" -o "$PROVIDER" = "libvirt" ]
-then
-  /vagrant/install/script-08.sh $PROVIDER
-fi
+/vagrant/install/script-08.sh $PROVIDER
 # Exit successfully
 echo "===> Script completed successfully!"
 exit 0

--- a/shared/Vagrantfile.common
+++ b/shared/Vagrantfile.common
@@ -26,6 +26,18 @@ Vagrant.configure('2') do |config|
       name:   "Configure /etc/hosts for AWS",
       inline: "
         echo \"`hostname -I` m1.example.com m1\" >> /etc/hosts
+        # Get primary IP
+        IPA=$(hostname -I | awk '{print $1}')
+        # Extract IP Range
+        IPRANGE=${IPA%.*}
+        # Try .200 as VIP
+        NEWIP=${IPRANGE}.200
+        if [ \"$NEWIP\" == \"$IPA\" ];
+        then
+          # In case 200 is taken, use different one
+          NEWIP=${IPRANGE}.201
+        fi
+        echo \"$NEWIP cesip.example.com cesip\" >> /etc/hosts
       "
   end
   # ... for VirtualBox
@@ -56,11 +68,14 @@ Vagrant.configure('2') do |config|
    "
 
   # Get fingerprint for management IP address
-  config.vm.provision "shell",
-    name:   "Get fingerprint for management IP address",
-    inline: "
-      ssh-keyscan -t ecdsa m1m.example.com >> /root/.ssh/known_hosts 2>/dev/null
-   "
+  if $SpectrumScaleVagrant_provider == 'VirtualBox' || $SpectrumScaleVagrant_provider == 'libvirt'
+  then
+    config.vm.provision "shell",
+      name:   "Get fingerprint for management IP address",
+      inline: "
+        /usr/bin/sudo /usr/bin/bash -c '/usr/bin/ssh-keyscan -t ecdsa m1m.example.com >> /root/.ssh/known_hosts'
+     "
+  end
 
   # Add Spectrum Scale executables to $PATH
   config.vm.provision "shell",


### PR DESCRIPTION
Fix issue #14 by adding the work-around as described in the vagrant-aws project to the Vagrantfiles.

Fix issue #15 which is in fact a vagrant-aws one by documenting a work-around.

Fix issue #16 by exempting the management network key configuration for the AWS deployment. On AWS there exists no management network.

Object deployment is supported by adding a VIP address to the single NIC on an AWS deployment and using that for the CES services as well as for the Spectrum Scale cluster network. As a pre-req the AWS deployment is now also based on CentOS 8 and Spectrum Scale Developer Edition 5.1.1.