### PR TITLE
Remove S3 region setting to leverage the 5.1.x default.

### DIFF
--- a/setup/demo/script-08.sh
+++ b/setup/demo/script-08.sh
@@ -39,10 +39,6 @@ case $1 in
     ;;
 esac
 
-# Prepare Object Storage to accept AWSv4 Authentication
-echo "===> Preparing S3 Object for AWSv4 Authentication - use US as region with your client software"
-sudo mmobj config change --ccrfile "proxy-server.conf" --section "filter:s3api" --property "location" --value "US"
-
 # Copy credentials file to user directory and use it
 echo "===> Copy object credentials file and source it"
 TARGET=vagrant


### PR DESCRIPTION
Starting with Spectrum Scale 5.1.0.1, it is no longer required to set the Spectrum Scale Object location parameter to `US` so that AWSv4 authentication can be used. Instead, the s3api implementation uses `us-east-1` as default region/location setting and supports AWSv4 authentication without any additional change. That also complies with most of the client software (awscli etc.) defaults.