### PR TITLE
Upgrade to Spectrum Scale Developer Edition 5.1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Open a Command Prompt and clone the GitHub repository:
 
 The creation of the Spectrum Scale cluster requires the Spectrum Scale self-extracting installation package. The developer edition can be downloaded from the [Spectrum Scale home page](https://www.ibm.com/products/spectrum-scale/).
 
-Download the `Spectrum_Scale_Developer-5.1.1.0-x86_64-Linux-install` package and save it to directory `SpectrumScaleVagrant\software` on the `host`.
+Download the `Spectrum_Scale_Developer-5.1.2.0-x86_64-Linux-install` package and save it to directory `SpectrumScaleVagrant\software` on the `host`.
+
+Please note that in case the Spectrum Scale Developer version you downloaded is newer than the one we listed here, you still might want to use the new version. You need to update the `$SpectrumScale_version` variable in [Vagrantfile.common](shared/Vagrantfile.common) to match the version you downloaded before continuing.
 
 Vagrant will copy this file during the provisioning from the `host` to directory `/software` on the management node `m1`.
 

--- a/aws/Vagrantfile
+++ b/aws/Vagrantfile
@@ -108,7 +108,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell",
     name:   "Install and configure single node Spectrum Scale cluster",
     inline: "
-      /vagrant/install/script.sh #{$SpectrumScaleVagrant_provider}
+      /vagrant/install/script.sh #{$SpectrumScaleVagrant_provider} #{$SpectrumScale_version}
     "
 
   # Configure Spectrum Scale for demo purposes

--- a/libvirt/Vagrantfile
+++ b/libvirt/Vagrantfile
@@ -88,7 +88,7 @@ Vagrant.configure("2") do |config|
     node.vm.provision "shell",
       name:   "Install and configure single node Spectrum Scale cluster",
       inline: "
-        /vagrant/install/script.sh #{$SpectrumScaleVagrant_provider}
+        /vagrant/install/script.sh #{$SpectrumScaleVagrant_provider} #{$SpectrumScale_version}
       "
 
     # Configure Spectrum Scale for demo purposes

--- a/setup/install/common-preamble.sh
+++ b/setup/install/common-preamble.sh
@@ -1,0 +1,41 @@
+usage(){
+  echo "Usage: $0 <provider> <spectrumscale-version>"
+  echo "Supported <provider>:"
+  echo "  AWS"
+  echo "  Virtualbox"
+  echo "  libvirt"
+  echo "<spectrumscale-version> is the full version number like 5.1.2.0"
+}
+
+# Improve readability of output
+echo "========================================================================================="
+echo "===>"
+echo "===> Running $0"
+echo -e "===> $TASK"
+echo "===>"
+echo "========================================================================================="
+
+# Print commands and their arguments as they are executed
+set -x
+
+# Exit script immediately, if one of the commands returns error code
+set -e
+
+# Exit, if not exactly two arguments are given
+if [ $# -ne 2 ]; then
+  usage
+  exit -1
+fi
+
+# Use first argument as current underlying provider
+case $1 in
+  'AWS'|'VirtualBox'|'libvirt' )
+    PROVIDER=$1
+    ;;
+  *)
+    usage
+    exit -1
+    ;;
+esac
+
+VERSION=$2

--- a/setup/install/script-01.sh
+++ b/setup/install/script-01.sh
@@ -1,23 +1,11 @@
 #!/usr/bin/bash
 
-# Improve readability of output
-echo "========================================================================================="
-echo "===>"
-echo "===> Running $0"
-echo "===> Check that Spectrum Scale self-extracting install package exists"
-echo "===>"
-echo "========================================================================================="
+TASK="Check that Spectrum Scale self-extracting install package exists"
 
-# Print commands and their arguments as they are executed
-set -x
-
-# Exit script immediately, if one of the commands returns error code
-set -e
-
+source /vagrant/install/common-preamble.sh
 
 # Pin the version and the edition of Spectrum Scale, until project runs stable for a while
-#install=/software/Spectrum_Scale_Data_Management-5.1.1.0-x86_64-Linux-install
-install=/software/Spectrum_Scale_Developer-5.1.1.0-x86_64-Linux-install
+install=/software/Spectrum_Scale_Developer-$VERSION-x86_64-Linux-install
 # Abort with error code, if Spectrum Scale self-extracting installation package not found
 echo "===> Check for Spectrum Scale self-extracting installation package"
 if [ ! -f $install ]; then

--- a/setup/install/script-02.sh
+++ b/setup/install/script-02.sh
@@ -1,23 +1,11 @@
 #!/usr/bin/bash
 
-# Improve readability of output
-echo "========================================================================================="
-echo "===>"
-echo "===> Running $0"
-echo "===> Extract Spectrum Scale RPMs"
-echo "===>"
-echo "========================================================================================="
+TASK="Extract Spectrum Scale RPMs"
 
-# Print commands and their arguments as they are executed
-set -x
-
-# Exit script immediately, if one of the commands returns error code
-set -e
-
+source /vagrant/install/common-preamble.sh
 
 # Pin the version and the edition of Spectrum Scale, until project runs stable for a while
-#install=/software/Spectrum_Scale_Data_Management-5.1.1.0-x86_64-Linux-install
-install=/software/Spectrum_Scale_Developer-5.1.1.0-x86_64-Linux-install
+install=/software/Spectrum_Scale_Developer-$VERSION-x86_64-Linux-install
 # Abort with error code, if Spectrum Scale directroy exists
 echo "===> Check for Spectrum Scale directrory"
 if [ -d "/usr/lpp/mmfs" ]; then

--- a/setup/install/script-03.sh
+++ b/setup/install/script-03.sh
@@ -1,46 +1,8 @@
 #!/usr/bin/bash
 
+TASK="Setup management node (m1) as Spectrum Scale Install Node"
 
-usage(){
-  echo "Usage: $0 [<provider>]"
-  echo "Supported provider:"
-  echo "  AWS"
-  echo "  VirtualBox"
-  echo "  libvirt"
-}
-
-
-# Improve readability of output
-echo "========================================================================================="
-echo "===>"
-echo "===> Running $0"
-echo "===> Setup management node (m1) as Spectrum Scale Install Node"
-echo "===>"
-echo "========================================================================================="
-
-# Print commands and their arguments as they are executed
-set -x
-
-# Exit script immediately, if one of the commands returns error code
-set -e
-
-
-# Exit, if not exactly one argument given
-if [ $# -ne 1 ]; then
-  usage
-  exit -1
-fi
-
-# Use first argument as current underlying provider
-case $1 in
-  'AWS'|'VirtualBox'|'libvirt' )
-    PROVIDER=$1
-    ;;
-  *)
-    usage
-    exit -1
-    ;;
-esac
+source /vagrant/install/common-preamble.sh
 
 # Determine SpectrumScale Install Node
 # ... for AWS
@@ -56,8 +18,8 @@ fi
 
 # Setup management node (m1) as Spectrum Scale Install Node
 echo "===> Setup management node (m1) as Spectrum Scale Install Node"
-sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale setup -s $INSTALL_NODE --storesecret
-sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale node list
+sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale setup -s $INSTALL_NODE --storesecret
+sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale node list
 
 
 # Exit successfully

--- a/setup/install/script-04.sh
+++ b/setup/install/script-04.sh
@@ -1,90 +1,51 @@
 #!/usr/bin/bash
 
-usage(){
-  echo "Usage: $0 [<provider>]"
-  echo "Supported provider:"
-  echo "  AWS"
-  echo "  VirtualBox"
-  echo "  libvirt"
-}
+TASK="Specify Spectrum Scale Cluster\n===> Target configuration: Single Node Cluster"
 
-
-# Improve readability of output
-echo "========================================================================================="
-echo "===>"
-echo "===> Running $0"
-echo "===> Specify Spectrum Scale Cluster"
-echo "===> Target configuration: Single Node Cluster"
-echo "===>"
-echo "========================================================================================="
-
-# Print commands and their arguments as they are executed
-set -x
-
-# Exit script immediately, if one of the commands returns error code
-set -e
-
-
-# Exit, if not exactly one argument given
-if [ $# -ne 1 ]; then
-  usage
-  exit -1
-fi
-
-# Use first argument as current underlying provider
-case $1 in
-  'AWS'|'VirtualBox'|'libvirt' )
-    PROVIDER=$1
-    ;;
-  *)
-    usage
-    exit -1
-    ;;
-esac
-
+source /vagrant/install/common-preamble.sh
 
 # Specify cluster name to 'demo'
 echo "===> Specify cluster name"
-sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale config gpfs -c demo
+sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale config gpfs -c demo
 
 # Disable callhome for demo environment
 echo "===> Specify to disable call home"
-sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale callhome disable
+sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale callhome disable
 
 # Specify nodes and its roles
 echo "===> Specify nodes and their roles"
-sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale node add -a -g -q -m -n m1
+sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale node add -a -g -q -m -n m1
 
 # Show cluster specification
 echo "===> Show cluster specification"
-sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale node list
+sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale node list
 
 # Specify NSDs
 # ... for AWS
 if [ "$PROVIDER" = "AWS" ]
 then
-  sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale nsd add -p m1.example.com -fs fs1 /dev/xvdb /dev/xvdc /dev/xvdd
-  sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale nsd add -p m1.example.com -fs cesShared /dev/xvde /dev/xvdf
-  sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale nsd add -p m1.example.com /dev/xvdg /dev/xvdh
+  sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale nsd add -p m1.example.com -fs fs1 /dev/xvdb /dev/xvdc /dev/xvdd
+  sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale nsd add -p m1.example.com -fs cesShared /dev/xvde /dev/xvdf
+  sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale nsd add -p m1.example.com /dev/xvdg /dev/xvdh
 fi
 # ... for VirtualBox
 if [ "$PROVIDER" = "VirtualBox" ]
 then
-  sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale nsd add -p m1.example.com -fs fs1 /dev/sdb /dev/sdc /dev/sdd
-  sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale nsd add -p m1.example.com -fs cesShared /dev/sde /dev/sdf
-  sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale nsd add -p m1.example.com /dev/sdg /dev/sdh
+  sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale nsd add -p m1.example.com -fs fs1 /dev/sdb /dev/sdc /dev/sdd
+  sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale nsd add -p m1.example.com -fs cesShared /dev/sde /dev/sdf
+  sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale nsd add -p m1.example.com /dev/sdg /dev/sdh
 fi
 # ... and Libvirt
 if [ "$PROVIDER" = "libvirt" ]
 then
-  sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale nsd add -p m1.example.com -fs fs1 /dev/vdb /dev/vdc /dev/vdd
-  sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale nsd add -p m1.example.com -fs cesShared /dev/vde /dev/vdf
-  sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale nsd add -p m1.example.com /dev/vdg /dev/vdh
+  sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale nsd add -p m1.example.com -fs fs1 /dev/vdb /dev/vdc /dev/vdd
+  sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale nsd add -p m1.example.com -fs cesShared /dev/vde /dev/vdf
+  sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale nsd add -p m1.example.com /dev/vdg /dev/vdh
 fi
 
 # Show NSD specification
 echo "===> Show NSD specification"
-sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale nsd list
+sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale nsd list
 
 
 # Exit successfully

--- a/setup/install/script-05.sh
+++ b/setup/install/script-05.sh
@@ -1,26 +1,12 @@
 #!/usr/bin/bash
 
-# Exit on error
-set -e
+TASK="Install Spectrum Scale and create a Spectrum Scale cluster"
 
-# Improve readability of output
-echo "========================================================================================="
-echo "===>"
-echo "===> Running $0"
-echo "===> Install Spectrum Scale and create a Spectrum Scale cluster"
-echo "===>"
-echo "========================================================================================="
-
-# Print commands and their arguments as they are executed
-set -x
-
-# Exit script immediately, if one of the commands returns error code
-set -e
-
+source /vagrant/install/common-preamble.sh
 
 # Install Spectrum Scale and create Spectrum Scale cluster
 echo "===> Install Spectrum Scale and create Spectrum Scale cluster"
-sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale install
+sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale install
 
 ## Change admin interface
 #  Note: Disable configuration of separate admin network, because

--- a/setup/install/script-06.sh
+++ b/setup/install/script-06.sh
@@ -1,30 +1,16 @@
 #!/usr/bin/bash
 
-# Exit on error
-set -e
+TASK="Create Spectrum Scale filesystems"
 
-# Improve readability of output
-echo "========================================================================================="
-echo "===>"
-echo "===> Running $0"
-echo "===> Create Spectrum Scale filesystems"
-echo "===>"
-echo "========================================================================================="
-
-# Print commands and their arguments as they are executed
-set -x
-
-# Exit script immediately, if one of the commands returns error code
-set -e
-
+source /vagrant/install/common-preamble.sh
 
 # Show Spectrum Scale filesystem specification
 echo "===> Show filesystem specification"
-sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale filesystem list
+sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale filesystem list
 
 # Create Spectrum Scale filesystems
 echo "===> Create Spectrum Scale filesystems"
-sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale deploy
+sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale deploy
 
 # Enable quotas
 echo "===> Enable quotas"

--- a/setup/install/script-07.sh
+++ b/setup/install/script-07.sh
@@ -1,22 +1,8 @@
 #!/usr/bin/bash
 
-# Exit on error
-set -e
+TASK="Tune sensors for demo environment"
 
-# Improve readability of output
-echo "========================================================================================="
-echo "===>"
-echo "===> Running $0"
-echo "===> Tune sensors for demo environment"
-echo "===>"
-echo "========================================================================================="
-
-# Print commands and their arguments as they are executed
-set -x
-
-# Exit script immediately, if one of the commands returns error code
-set -e
-
+source /vagrant/install/common-preamble.sh
 
 # Tune sensors for demo environment
 echo "===> Tune sensors for demo environment"

--- a/setup/install/script-08.sh
+++ b/setup/install/script-08.sh
@@ -1,43 +1,8 @@
 #!/usr/bin/bash
 
-usage(){
-  echo "Usage: $0 [<provider>]"
-  echo "Supported provider:"
-  echo "  AWS"
-  echo "  VirtualBox"
-  echo "  libvirt"
-}
+TASK="Installing Object protocol"
 
-# Improve readability of output
-echo "========================================================================================="
-echo "===>"
-echo "===> Running $0"
-echo "===> Installing Object protocol"
-echo "===>"
-echo "========================================================================================="
-
-# Print commands and their arguments as they are executed
-set -x
-
-# Exit script immediately, if one of the commands returns error code
-set -e
-
-# Exit, if not exactly one argument given
-if [ $# -ne 1 ]; then
-  usage
-  exit -1
-fi
-
-# Use first argument as current underlying provider
-case $1 in
-  'AWS'|'VirtualBox'|'libvirt' )
-    PROVIDER=$1
-    ;;
-  *)
-    usage
-    exit -1
-    ;;
-esac
+source /vagrant/install/common-preamble.sh
 
 echo "===> Installing prereqs"
 sudo dnf -y install centos-release-openstack-train
@@ -45,14 +10,14 @@ sudo dnf config-manager --set-enabled powertools
 sudo dnf -y upgrade
 
 echo "===> configuring Object"
-sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale node add m1.example.com -p
+sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale node add m1.example.com -p
 CESVIP=$(grep "cesip" /etc/hosts | awk {'print $1'})
-sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale config protocols -e $CESVIP
-sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale config protocols -f cesShared -m /ibm/cesShared
-sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale enable object
-sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale config object -f fs1 -m /ibm/fs1 -e cesip.example.com -au admin -dp passw0rd -sp passw0rd -ap passw0rd
-sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale config object -s3 on -i 50000
-sudo /usr/lpp/mmfs/5.1.1.0/ansible-toolkit/spectrumscale deploy
+sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale config protocols -e $CESVIP
+sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale config protocols -f cesShared -m /ibm/cesShared
+sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale enable object
+sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale config object -f fs1 -m /ibm/fs1 -e cesip.example.com -au admin -dp passw0rd -sp passw0rd -ap passw0rd
+sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale config object -s3 on -i 50000
+sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale deploy
 
 # Exit successfully
 echo "===> Script completed successfully!"

--- a/setup/install/script.sh
+++ b/setup/install/script.sh
@@ -1,57 +1,18 @@
 #!/usr/bin/bash
 
+TASK="Perform all steps to provision a Spectrum Scale cluster"
 
-usage(){
-  echo "Usage: $0 [<provider>]"
-  echo "Supported provider:"
-  echo "  AWS"
-  echo "  Virtualbox"
-  echo "  libvirt"
-}
-
-
-# Improve readability of output
-echo "========================================================================================="
-echo "===>"
-echo "===> Running $0"
-echo "===> Perform all steps to provision a Spectrum Scale cluster"
-echo "===>"
-echo "========================================================================================="
-
-# Print commands and their arguments as they are executed
-set -x
-
-# Exit script immediately, if one of the commands returns error code
-set -e
-
-
-# Exit, if not exactly one argument given
-if [ $# -ne 1 ]; then
-  usage
-  exit -1
-fi
-
-# Use first argument as current underlying provider
-case $1 in
-  'AWS'|'VirtualBox'|'libvirt' )
-    PROVIDER=$1
-    ;;
-  *)
-    usage
-    exit -1
-    ;;
-esac
-
+source /vagrant/install/common-preamble.sh
 
 # Perform all steps to provision Spectrum Scale Cluster
-/vagrant/install/script-01.sh $PROVIDER
-/vagrant/install/script-02.sh $PROVIDER
-/vagrant/install/script-03.sh $PROVIDER
-/vagrant/install/script-04.sh $PROVIDER
-/vagrant/install/script-05.sh $PROVIDER
-/vagrant/install/script-06.sh $PROVIDER
-/vagrant/install/script-07.sh $PROVIDER
-/vagrant/install/script-08.sh $PROVIDER
+/vagrant/install/script-01.sh $PROVIDER $VERSION
+/vagrant/install/script-02.sh $PROVIDER $VERSION
+/vagrant/install/script-03.sh $PROVIDER $VERSION
+/vagrant/install/script-04.sh $PROVIDER $VERSION
+/vagrant/install/script-05.sh $PROVIDER $VERSION
+/vagrant/install/script-06.sh $PROVIDER $VERSION
+/vagrant/install/script-07.sh $PROVIDER $VERSION
+/vagrant/install/script-08.sh $PROVIDER $VERSION
 # Exit successfully
 echo "===> Script completed successfully!"
 exit 0

--- a/shared/Vagrantfile.common
+++ b/shared/Vagrantfile.common
@@ -6,6 +6,8 @@
 # This file should be included by the Vagrantfile of each cluster configuration
 #
 
+$SpectrumScale_version = "5.1.2.0"
+
 Vagrant.configure('2') do |config|
 
   # Sync folders and files from host to guests
@@ -90,6 +92,5 @@ Vagrant.configure('2') do |config|
     inline: "
       cp /vagrant/files/linux/etc__sudoers.d__spectrumscale /etc/sudoers.d/spectrumscale
    "
-
 
 end

--- a/virtualbox/Vagrantfile
+++ b/virtualbox/Vagrantfile
@@ -90,7 +90,7 @@ Vagrant.configure("2") do |config|
     node.vm.provision "shell",
       name:   "Install and configure single node Spectrum Scale cluster",
       inline: "
-        /vagrant/install/script.sh #{$SpectrumScaleVagrant_provider}
+        /vagrant/install/script.sh #{$SpectrumScaleVagrant_provider} #{$SpectrumScale_version}
       "
 
     # Configure Spectrum Scale for demo purposes


### PR DESCRIPTION
In addition to changing the Spectrum Scale version number, refactored the install scripts to reduce code duplication and make it easier to change the version number - in one place only.
The way to perform "self-service" Spectrum Scale version number changes is documented in the README.
