### PR TITLE
Spectrum Scale 5.1.3.0, Contain Centos8 EOL, Add Disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Open a Command Prompt and clone the GitHub repository:
 
 The creation of the Spectrum Scale cluster requires the Spectrum Scale self-extracting installation package. The developer edition can be downloaded from the [Spectrum Scale home page](https://www.ibm.com/products/spectrum-scale/).
 
-Download the `Spectrum_Scale_Developer-5.1.2.2-x86_64-Linux-install` package and save it to directory `SpectrumScaleVagrant\software` on the `host`.
+Download the `Spectrum_Scale_Developer-5.1.3.0-x86_64-Linux-install` package and save it to directory `SpectrumScaleVagrant\software` on the `host`.
 
 Please note that in case the Spectrum Scale Developer version you downloaded is newer than the one we listed here, you still might want to use the new version. You need to update the `$SpectrumScale_version` variable in [Vagrantfile.common](shared/Vagrantfile.common) to match the version you downloaded before continuing.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spectrum Scale Vagrant
-Example scripts and configuration files to install and configure IBM Spectrum Scale in a Vagrant environment.
 
+Example scripts and configuration files to install and configure IBM Spectrum Scale in a Vagrant environment.
 
 ## Installation
 
@@ -16,7 +16,7 @@ Open a Command Prompt and clone the GitHub repository:
 
 The creation of the Spectrum Scale cluster requires the Spectrum Scale self-extracting installation package. The developer edition can be downloaded from the [Spectrum Scale home page](https://www.ibm.com/products/spectrum-scale/).
 
-Download the `Spectrum_Scale_Developer-5.1.2.0-x86_64-Linux-install` package and save it to directory `SpectrumScaleVagrant\software` on the `host`.
+Download the `Spectrum_Scale_Developer-5.1.2.2-x86_64-Linux-install` package and save it to directory `SpectrumScaleVagrant\software` on the `host`.
 
 Please note that in case the Spectrum Scale Developer version you downloaded is newer than the one we listed here, you still might want to use the new version. You need to update the `$SpectrumScale_version` variable in [Vagrantfile.common](shared/Vagrantfile.common) to match the version you downloaded before continuing.
 
@@ -297,3 +297,10 @@ Maximum number of inodes:       107520
 
 [vagrant@m1 ~]$
 ```
+
+## Disclaimer
+
+**Please note:** This project is released for use "AS IS" without any warranties of any kind, including, but not limited to installation, use, or performance of the resources in this repository.
+We are not responsible for any damage, data loss or charges incurred with their use.
+This project is outside the scope of the IBM PMR process. If you have any issues, questions or suggestions you can create a new issue [here](https://github.com/IBM/SpectrumScaleVagrant/issues).
+Issues will be addressed as team availability permits.

--- a/aws/README.md
+++ b/aws/README.md
@@ -83,8 +83,8 @@ SpectrumScaleVagrant\aws\prep-ami>vagrant ssh
 
 [centos@ip-172-31-27-143 ~]$ ls -l /software
 -rw-rw-r--.  1 centos centos        134 16. Jun 10:09 README
--r-xr-xr-x.  1 centos centos 1407530361 16. Jun 13:11 Spectrum_Scale_Developer-5.1.1.0-x86_64-Linux-install
--rw-rw-r--.  1 centos centos         88 16. Jun 13:11 Spectrum_Scale_Developer-5.1.1.0-x86_64-Linux-install.md5
+-r-xr-xr-x.  1 centos centos 1173021210 16. Jun 13:11 Spectrum_Scale_Developer-5.1.3.0-x86_64-Linux-install
+-rw-rw-r--.  1 centos centos         88 16. Jun 13:11 Spectrum_Scale_Developer-5.1.3.0-x86_64-Linux-install.md5
 
 [centos@ip-172-31-27-143 ~]$ exit
 logout

--- a/libvirt/prep-box/Vagrantfile
+++ b/libvirt/prep-box/Vagrantfile
@@ -33,7 +33,7 @@ Vagrant.configure("2") do |config|
     libvirt.qemu_use_session = false
   end
 
-  # Official CentOS 7 box
+  # Official CentOS 8 box
   config.vm.box = "centos/8"
 
   # Pin the version of the CentOS box, until project runs stable for a while

--- a/setup/install/common-preamble.sh
+++ b/setup/install/common-preamble.sh
@@ -4,7 +4,7 @@ usage(){
   echo "  AWS"
   echo "  Virtualbox"
   echo "  libvirt"
-  echo "<spectrumscale-version> is the full version number like 5.1.2.2"
+  echo "<spectrumscale-version> is the full version number like 5.1.3.0"
 }
 
 # Improve readability of output

--- a/setup/install/common-preamble.sh
+++ b/setup/install/common-preamble.sh
@@ -4,7 +4,7 @@ usage(){
   echo "  AWS"
   echo "  Virtualbox"
   echo "  libvirt"
-  echo "<spectrumscale-version> is the full version number like 5.1.2.0"
+  echo "<spectrumscale-version> is the full version number like 5.1.2.2"
 }
 
 # Improve readability of output

--- a/setup/install/script-08.sh
+++ b/setup/install/script-08.sh
@@ -4,11 +4,6 @@ TASK="Installing Object protocol"
 
 source /vagrant/install/common-preamble.sh
 
-echo "===> Installing prereqs"
-sudo dnf -y install centos-release-openstack-train
-sudo dnf config-manager --set-enabled powertools
-sudo dnf -y upgrade
-
 echo "===> configuring Object"
 sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale node add m1.example.com -p
 CESVIP=$(grep "cesip" /etc/hosts | awk {'print $1'})
@@ -17,8 +12,16 @@ sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale config protocols -f ce
 sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale enable object
 sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale config object -f fs1 -m /ibm/fs1 -e cesip.example.com -au admin -dp passw0rd -sp passw0rd -ap passw0rd
 sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale config object -s3 on -i 50000
+set +e
 sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale deploy
-
+if [ $? != 0 ]; then
+    # CES IP might not yet have been assigned to the node when the deployment is configuring object
+    #  -> deployment fails with error "mmobj swift base: No CES IP addresses are assigned to this node"
+    # first seen with 5.1.2.2, to work-around sleep a while, then re-try
+    sleep 30
+    set -e
+    sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale deploy
+fi
 # Exit successfully
 echo "===> Script completed successfully!"
 exit 0

--- a/shared/Vagrantfile.common
+++ b/shared/Vagrantfile.common
@@ -6,7 +6,7 @@
 # This file should be included by the Vagrantfile of each cluster configuration
 #
 
-$SpectrumScale_version = "5.1.2.2"
+$SpectrumScale_version = "5.1.3.0"
 
 Vagrant.configure('2') do |config|
 

--- a/shared/Vagrantfile.common
+++ b/shared/Vagrantfile.common
@@ -6,7 +6,7 @@
 # This file should be included by the Vagrantfile of each cluster configuration
 #
 
-$SpectrumScale_version = "5.1.2.0"
+$SpectrumScale_version = "5.1.2.2"
 
 Vagrant.configure('2') do |config|
 

--- a/shared/Vagrantfile8.rpms
+++ b/shared/Vagrantfile8.rpms
@@ -10,6 +10,12 @@
 
 Vagrant.configure('2') do |config|
 
+  # Contain CentOS 8 EOL
+  config.vm.provision "shell",
+    name:   "Switch to CentOS 8 Vault Mirror repository after CentOS 8 2021/12/31 EOL",
+    inline: "
+      /bin/sh -c 'sed -i \"s/mirrorlist/#mirrorlist/g\" /etc/yum.repos.d/CentOS-* && sed -i \"s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g\" /etc/yum.repos.d/CentOS-*'
+    "
 
   # Upgrade everything to prevent kernel version mismatches
   config.vm.provision "shell",


### PR DESCRIPTION
Now using Spectrum Scale Developer Edition 5.1.3.0.
With that version, the OpenStack packages are provided by Spectrum Scale (again).
We contain the CentOS 8 EOL YE2021 by switching to the Centos vault repository.
Added a disclaimer to clarify project support status.