### PR TITLE
Support for Scale 5.1.5.0, fix Ansible dependency, disable EPEL before Scale installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Open a Command Prompt and clone the GitHub repository:
 
 The creation of the Spectrum Scale cluster requires the Spectrum Scale self-extracting installation package. The developer edition can be downloaded from the [Spectrum Scale home page](https://www.ibm.com/products/spectrum-scale/).
 
-Download the `Spectrum_Scale_Developer-5.1.4.1-x86_64-Linux-install` package and save it to directory `SpectrumScaleVagrant\software` on the `host`.
+Download the `Spectrum_Scale_Developer-5.1.5.0-x86_64-Linux-install` package and save it to directory `SpectrumScaleVagrant\software` on the `host`.
 
 Please note that in case the Spectrum Scale Developer version you downloaded is newer than the one we listed here, you still might want to use the new version. You need to update the `$SpectrumScale_version` variable in [Vagrantfile.common](shared/Vagrantfile.common) to match the version you downloaded before continuing.
 

--- a/aws/README.md
+++ b/aws/README.md
@@ -83,9 +83,9 @@ SpectrumScaleVagrant\aws\prep-ami>vagrant ssh
 
 [centos@ip-172-31-27-143 ~]$ ls -l software/
 total 1283864
--rw-r--r--. 1 centos centos 1365017135 12. Jul 13:34 Spectrum_Scale_Developer-5.1.4.1-x86_64-Linux-install
--rw-r--r--. 1 centos centos         88 12. Jul 13:35 Spectrum_Scale_Developer-5.1.4.1-x86_64-Linux-install.md5
--rw-r--r--. 1 centos centos       4035 14. Jul 03:00 Spectrum_Scale_Developer-5.1.4.1-x86_64-Linux.README
+-rw-r--r--. 1 centos centos 1315520852 25. Aug 18:40 Spectrum_Scale_Developer-5.1.5.0-x86_64-Linux-install
+-rw-r--r--. 1 centos centos         88 25. Aug 18:40 Spectrum_Scale_Developer-5.1.5.0-x86_64-Linux-install.md5
+-rw-r--r--. 1 centos centos       4035 15. Jul 14:21 Spectrum_Scale_Developer-5.1.5.0-x86_64-Linux.README
 
 [centos@ip-172-31-27-143 ~]$ exit
 logout

--- a/setup/install/common-preamble.sh
+++ b/setup/install/common-preamble.sh
@@ -4,7 +4,7 @@ usage(){
   echo "  AWS"
   echo "  Virtualbox"
   echo "  libvirt"
-  echo "<spectrumscale-version> is the full version number like 5.1.4.1"
+  echo "<spectrumscale-version> is the full version number like 5.1.5.0"
 }
 
 # Improve readability of output

--- a/shared/Vagrantfile.common
+++ b/shared/Vagrantfile.common
@@ -6,7 +6,7 @@
 # This file should be included by the Vagrantfile of each cluster configuration
 #
 
-$SpectrumScale_version = "5.1.4.1"
+$SpectrumScale_version = "5.1.5.0"
 
 Vagrant.configure('2') do |config|
 

--- a/shared/Vagrantfile8.rpms
+++ b/shared/Vagrantfile8.rpms
@@ -34,7 +34,7 @@ Vagrant.configure('2') do |config|
     "
 
   # Install RPMs required by Spectrum Scale core
-    config.vm.provision "shell",
+  config.vm.provision "shell",
     name:   "Install RPMs required by Spectrum Scale core",
     inline: "
       /usr/bin/dnf install -y\
@@ -42,15 +42,6 @@ Vagrant.configure('2') do |config|
         m4\
         libaio
     "
-
-  # Remove installed kernel-devel and kernel-headers to prevent version mismatches
-  # config.vm.provision "shell",
-  #   name:   "Remove installed kernel-devel and kernel-headers to prevent version mismatches",
-  #   inline: "
-  #     /usr/bin/dnf remove -y\
-  #       kernel-devel\
-  #       kernel-headers\
-  #  "
 
   # Install RPMs required by Spectrum Scale to build portability layer
   config.vm.provision "shell",
@@ -108,15 +99,15 @@ Vagrant.configure('2') do |config|
       /bin/sh -c \"sed -i 's/metalink/#metalink/g' /etc/yum.repos.d/epel*\" && /bin/sh -c \"sed -i 's|#baseurl=https://download.example/pub/|baseurl=https://mirror.init7.net/fedora/|g' /etc/yum.repos.d/epel*\"
     "
 
-  # Install Ansible as required by Spectrum Scale 5.1.1+ installer
-    config.vm.provision "shell",
-    name:   "Install additional RPMs required by Spectrum Scale",
+  # Install Ansible via PIP (RPM installation is broken for Centos8)
+  config.vm.provision "shell",
+    name:   "Install Ansible as required by Spectrum Scale 5.1.1+ installer",
     inline: "
-      /usr/bin/dnf makecache && /usr/bin/dnf install -y ansible
+      /usr/bin/dnf -y install rust libsodium python3-paramiko python3-pynacl && pip3 install setuptools_rust && pip3 install ansible==2.9.27
     "
 
   # Install RPM to prevent CLI errors due to locale for German users
-    config.vm.provision "shell",
+  config.vm.provision "shell",
     name:   "Install locale RPM",
     inline: "
       /usr/bin/dnf install -y\
@@ -128,5 +119,12 @@ Vagrant.configure('2') do |config|
     name:   "Upgrade everything to ensure versions are in sync after pulling packages from EPEL",
     inline: "
       /usr/bin/dnf upgrade -y
+    "
+
+  # Disable EPEL
+  config.vm.provision "shell",
+    name:   "Disable EPEL to prevent package conflicts during Spectrum Scale installation",
+    inline: "
+      /bin/sh -c \"sed -i 's/enabled=1/enabled=0/g' /etc/yum.repos.d/epel*\"
     "
 end


### PR DESCRIPTION
The Ansible dependency fix is supposed to address https://github.com/IBM/SpectrumScaleVagrant/issues/27